### PR TITLE
Use stat for file size, and get output / error in parallel

### DIFF
--- a/HCCGo/app/html/jobView.html
+++ b/HCCGo/app/html/jobView.html
@@ -6,8 +6,8 @@
       <div class="well">
         <h3 class="text-center">{{job.jobName}} - {{job.jobId}}</h3>
         <hr />
-        <p><strong>Output:</strong> {{job.outText}}</p>
-        <p><strong>Error:</strong> {{job.errText}}</p>
+        <p><strong>Output:</strong> {{outText}}</p>
+        <p><strong>Error:</strong> {{errText}}</p>
         <p><strong>Time Elapsed:</strong> {{job.elapsed}}</p>
         <p><strong>Required Memory:</strong> {{job.reqMem}}</p>
       </div>

--- a/HCCGo/app/js/jobViewCtrl.js
+++ b/HCCGo/app/js/jobViewCtrl.js
@@ -16,25 +16,29 @@ jobViewModule.controller('jobViewCtrl', ['$scope', '$log', '$timeout', 'connecti
       $scope.job = result;
     }
     else {
-      connectionService.getFileSize(result.outputPath + ' ' + result.errorPath).then(function(data) {
-        if(parseInt(data[result.outputPath].replace("kB","")) > 5000) {
-          result.outText = "The output file is too large to be displayed here."
-        }
-        else {
+      // In parallel, get the size of the output and error
+      connectionService.getFileSize(result.outputPath).then(function(size) {
+        // If the file is larger than 5MB
+        if(size > 5*1025*1024) {
+          $scope.outText = "The Output file is too large to be displayed here."
+        } else {
           connectionService.getFileText(result.outputPath).then(function(data) {
-            result.outText = data;
+            $scope.outText = data;
           });
         }
-        if(parseInt(data[result.errorPath].replace("kB","")) > 5000) {
-          result.errText = "The error file is too large to be displayed here."
-        }
-        else {
-          connectionService.getFileText(result.errorPath).then(function(data) {
-            result.errText = data.length>0 ? data : "(none)";
-          });
-        }
-        $scope.job = result;
+        
       });
+      
+      connectionService.getFileSize(result.errorPath).then(function(size) {
+        if(size > 5*1025*1024) {
+          $scope.errText = "The Error file is too large to be displayed here."
+        }
+        connectionService.getFileText(result.errorPath).then(function(data) {
+          $scope.errText = data.length>0 ? data : "(none)";
+        });
+      });
+      
+      
     }
   });
 


### PR DESCRIPTION
Here is some changes to your viewOutErr.

1. Use stat instead of running `ls`
2. Perform output and error read operations in parallel

Things you should do:

- [x] Use SFTP streams to read the data.
- [x] Put the output and error in their own boxes, with `<pre>` around them.  Also, the will have to scroll (some HTML work will need to be done here)